### PR TITLE
[WIP] Updates mini.zip url from archive.org saved url / change debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM debian:wheezy
 MAINTAINER Arulraj Venni <me@arulraj.net>
 
 # Install Apache, PHP5 and speedtest mini zip
+# 2021.10.20: Updated mini.zip url from last available archive.org archived url
 RUN apt-get update -qq \
   && apt-get install -y wget unzip apache2 php5 php5-mysql php5-gd php5-mcrypt \
-  && wget http://c.speedtest.net/mini/mini.zip -O /tmp/mini.zip \
+  && wget https://web.archive.org/web/20180218001701/http://c.speedtest.net/mini/mini.zip -O /tmp/mini.zip \
   && mkdir -p /var/www/mini \
   && unzip /tmp/mini.zip -d /var/www/ \
   && cd /var/www/mini \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -qq \
   && cd /var/www/mini \
   && mv index-php.html index.html \
   && mv * ../ \
-  && echo "ServerName localhost" | tee /etc/apache2/apache2.conf \
+  && echo "ServerName localhost" | tee -a /etc/apache2/apache2.conf \
   && apt-get clean autoclean \
   && apt-get autoremove -y \
   && rm -rf /var/lib/{apt,dpkg,cache,log}/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -qq \
   && cd /var/www/mini \
   && mv index-php.html index.html \
   && mv * ../ \
-  && echo "ServerName localhost" | tee /etc/apache2/conf.d/fqdn \
+  && echo "ServerName localhost" | tee /etc/apache2/apache2.conf \
   && apt-get clean autoclean \
   && apt-get autoremove -y \
   && rm -rf /var/lib/{apt,dpkg,cache,log}/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM debian:wheezy
+FROM debian:stretch
 
 MAINTAINER Arulraj Venni <me@arulraj.net>
 
 # Install Apache, PHP5 and speedtest mini zip
 # 2021.10.20: Updated mini.zip url from last available archive.org archived url
+# 2021.10.20: Updated php5-* packages to php-* to fit
 RUN apt-get update -qq \
-  && apt-get install -y wget unzip apache2 php5 php5-mysql php5-gd php5-mcrypt \
+  && apt-get install -y wget unzip apache2 php php-mysql php-gd php-mcrypt \
   && wget https://web.archive.org/web/20180218001701/http://c.speedtest.net/mini/mini.zip -O /tmp/mini.zip \
   && mkdir -p /var/www/mini \
   && unzip /tmp/mini.zip -d /var/www/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch
 
 MAINTAINER Arulraj Venni <me@arulraj.net>
 
-# Install Apache, PHP5 and speedtest mini zip
+# Install Apache, PHP and speedtest mini zip
 # 2021.10.20: Updated mini.zip url from last available archive.org archived url
 # 2021.10.20: Updated php5-* packages to php-* to fit
 RUN apt-get update -qq \


### PR DESCRIPTION
https://web.archive.org/web/20180218001701/http://c.speedtest.net/mini/mini.zip
seems to be latest viable option in terms of downloadable file. Still needs to be tested in ordr to see if nothing fails.